### PR TITLE
fix: merge goal continuation into primary system block (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `experimental.chat.system.transform` to merge the goal continuation block into the primary system entry instead of pushing a separate one. Prevents `"System message must be at the beginning."` errors on strict-template backends (Qwen on vLLM, several Llama.cpp/Mistral templates). See issue #1.
+
 ## 0.1.8 — 2026-05-18
 
 - Harden `--max-minutes` fallback arithmetic when mixed with millisecond duration overrides.

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -656,15 +656,19 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
       if (goal.stopped) return
       if (output.system.some((block) => block.includes("<goal_objective>"))) return
 
-      output.system.push(
-        [
-          buildGoalBlock(goal),
-          "Keep working until the goal is fully satisfied.",
-          "When fully satisfied, end the response with `[goal:complete]`.",
-          "If user input is required, explain the blocker in the line immediately before `[goal:blocked]`.",
-          buildLimitWarning(goal),
-        ].filter(Boolean).join("\n"),
-      )
+      const goalBlock = [
+        buildGoalBlock(goal),
+        "Keep working until the goal is fully satisfied.",
+        "When fully satisfied, end the response with `[goal:complete]`.",
+        "If user input is required, explain the blocker in the line immediately before `[goal:blocked]`.",
+        buildLimitWarning(goal),
+      ].filter(Boolean).join("\n")
+
+      if (output.system.length === 0) {
+        output.system.push(goalBlock)
+      } else {
+        output.system[0] = `${output.system[0]}\n\n${goalBlock}`
+      }
     },
   }
 }

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -150,6 +150,39 @@ test("system transform is idempotent", async () => {
   assert.match(output.system[0], /<goal_objective>\nship it\n<\/goal_objective>/)
 })
 
+test("system transform merges into existing system block instead of adding a second one", async () => {
+  const { hooks } = await createHooks()
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-1", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const basePrompt = "You are opencode, a coding assistant."
+  const output = { system: [basePrompt] }
+  await hooks["experimental.chat.system.transform"]({ sessionID: "session-1" }, output)
+
+  // Strict-template backends (e.g. Qwen on vLLM) reject any request with more
+  // than one role:"system" message. The goal block must be merged into the
+  // existing primary system entry, not pushed as a second array entry.
+  assert.equal(output.system.length, 1)
+  assert.ok(output.system[0].startsWith(basePrompt))
+  assert.match(output.system[0], /<goal_objective>\nship it\n<\/goal_objective>/)
+})
+
+test("system transform pushes a new block when system array is empty", async () => {
+  const { hooks } = await createHooks()
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-1", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const output = { system: [] }
+  await hooks["experimental.chat.system.transform"]({ sessionID: "session-1" }, output)
+
+  assert.equal(output.system.length, 1)
+  assert.match(output.system[0], /<goal_objective>\nship it\n<\/goal_objective>/)
+})
+
 test("session.status idle auto-continues once", async () => {
   const { calls, hooks } = await createHooks({ options: { minDelayMs: 1 } })
   await hooks["command.execute.before"](


### PR DESCRIPTION
## What changed

`experimental.chat.system.transform` now merges the goal continuation block into `output.system[0]` instead of `output.system.push(...)`-ing a second array entry. When the system array is empty, it falls back to pushing — preserving current behavior for callers that rely on goal-plugin owning the entire system prompt.

## Why

The previous `push` pattern produced **two consecutive `role: "system"` messages** on the wire. Backends that enforce the OpenAI convention of exactly one system message at index 0 reject this with HTTP 400 `"System message must be at the beginning."`. Affected backends include:

- **Qwen** family on vLLM (the Qwen3.5/3.6 chat templates `raise_exception` on a second system message)
- Several **Llama.cpp** templates
- Some **Mistral** templates

OpenAI's and Anthropic's hosted APIs silently tolerate multiple system messages, which is why this bug is invisible to users on those providers.

The opencode community has documented that plugins using `experimental.chat.system.transform` should merge rather than push (see [anomalyco/opencode#23660](https://github.com/anomalyco/opencode/issues/23660) and [anomalyco/opencode#15059](https://github.com/anomalyco/opencode/issues/15059)). This change brings goal-plugin in line with that guidance.

## How

```js
// before
output.system.push(
  [buildGoalBlock(goal), ...].filter(Boolean).join("\n"),
)

// after
const goalBlock = [buildGoalBlock(goal), ...].filter(Boolean).join("\n")
if (output.system.length === 0) {
  output.system.push(goalBlock)
} else {
  output.system[0] = `${output.system[0]}\n\n${goalBlock}`
}
```

## Verification

### Checks
```
$ npm run check
... 35 pass, 0 fail
$ npm run pack:check
... opencode-goal-plugin-0.1.8.tgz (12.0 kB)
```

### Manual OpenCode smoke test

Against opencode 1.15.11 with this plugin, provider `@ai-sdk/openai-compatible` pointing at vLLM 0.19.x serving Qwen3.5-122B-A10B (same setup as issue #1):

| Plugin code | Result |
|---|---|
| Original (`push`) | HTTP 400 from vLLM: `{"message":"System message must be at the beginning.","type":"BadRequestError","code":400}` |
| This PR (merge) | `/goal draw a ball` succeeds; model executes `write` tool, creates the artifact, step finishes cleanly with `reason: "tool-calls"`, goal auto-continues to next iteration |

Token usage in the passing case: 9120 input / 283 output — confirming both the base system prompt and the goal continuation block reach the model, just collapsed into a single `role: "system"` message instead of two.

## Tests

- **Existing** `"system transform is idempotent"` — unchanged, still passes (idempotence guard preserved).
- **New** `"merges into existing system block instead of adding a second one"` — pins the bug fix; asserts `output.system.length === 1` and the base prompt is preserved as a prefix.
- **New** `"pushes a new block when system array is empty"` — pins the empty-array fallback.

## Related

- Issue #1 in this repo (filed alongside this fix)
- [anomalyco/opencode#15059](https://github.com/anomalyco/opencode/issues/15059) — canonical upstream bug
- [anomalyco/opencode#23660](https://github.com/anomalyco/opencode/issues/23660) — guidance request for plugin authors

Closes #1.