### PR TITLE
fix: track context window size instead of cumulative API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## Unreleased
 
+## 0.1.13 — 2026-06-11
+
+> Fixes a significant token-tracking bug where the reported token count could be 5–10× higher than what OpenCode displays, making budgets appear exhausted far sooner than expected.
+
+- **Fix token tracking to use context window size instead of cumulative API consumption.** Each `message.updated` event carries `input + output + reasoning` tokens where `input` already includes the full conversation context. Accumulating deltas across messages re-counted prior turns every time, inflating the total. The plugin now uses `Math.max` across all message updates so `totalTokens` reflects the peak context window size — matching what OpenCode reports.
+- Rename `tracked_tokens_used` / `tracked_tokens_remaining` → `context_tokens_used` / `context_tokens_remaining` in continuation prompts.
+- Rename `Tokens:` → `Context tokens:` in status and result displays.
+- Rename `tracked token limit` / `tracked token budget` → `context token limit` / `context token budget` in all user-facing messages.
+- Add regression test verifying that multi-message token tracking no longer accumulates across turns.
+
 ## 0.1.12 — 2026-06-08
 
-- Harden `escapeGoalText` to escape all XML closing tags (`</` → `<\/`) instead of only `</goal_objective>`, closing a prompt-injection path where user-supplied goal text could break structural framing in the continuation message.
+- Harden `escapeGoalText` to escape all XML closing tags (`</` → `<\\/`) instead of only `</goal_objective>`, closing a prompt-injection path where user-supplied goal text could break structural framing in the continuation message.
 - Add unit tests for `outputTokensForMessage`, `budgetWrapupNeeded`, `getSessionID`, `stopReason`, `normalizeOptions` boundary inputs (zero, negative, NaN, null, `budgetWrapupRatio` at 0 and 1), and `escapeGoalText` covering all structural tags.
 
 ## 0.1.11 — 2026-06-04

--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ Markers must appear on their own final line. The bracketed form is canonical, bu
 |---|---|
 | Auto-continue turns | 10 |
 | Max duration | 15 minutes |
-| Tracked tokens | 200,000 |
+| Context tokens | 200,000 |
 | Min delay between continues | 1.5 seconds |
 | No-progress pause | < 50 output tokens on a stalled turn (after a 2-turn grace window) |
-| Budget wrap-up threshold | 80% of tracked token budget |
+| Budget wrap-up threshold | 80% of context token budget |
 | Auto-continue failure pause | 3 consecutive prompt failures |
 
 **Effective turn count.** Each LLM turn on a real task typically takes 30–90 seconds. At that latency, raising `--max-minutes` is usually more useful than raising `--max-turns`. At 45 s/turn, the default 15-minute window gives roughly 15–20 turns of headroom before the turn limit becomes the binding brake.
 
-**Token budget.** The plugin tracks `input + output + reasoning` tokens across all session messages. In high-context sessions (large codebases, long conversation history), input overhead per turn can be substantial and the budget may be exhausted before the turn limit is reached. Treat it as a safety brake, not precise billing accounting.
+**Token budget.** The plugin tracks the session's context window size (`input + output + reasoning` tokens on the latest message). This matches the token count that OpenCode displays, so the numbers should be consistent. When the context window reaches the `--max-tokens` limit, the plugin sends a wrap-up prompt and stops. In high-context sessions (large codebases, long conversation history), the context can grow quickly — treat the budget as a safety brake.
 
 **No-progress heuristic.** A low-output turn does not pause immediately anymore. The plugin pauses only after `noProgressTurnsBeforePause` consecutive *stalled* low-output turns — repeated turns with very little output and no meaningful change in the latest assistant checkpoint.
 
@@ -141,7 +141,7 @@ Override any limit for a single goal:
 | `--max-turns <n>` | Auto-continue turn limit |
 | `--max-minutes <n>` | Duration limit in minutes |
 | `--max-duration-ms <n>` | Duration limit in milliseconds |
-| `--max-tokens <n>` | Tracked token limit |
+| `--max-tokens <n>` | Context token limit |
 | `--cooldown-ms <n>` | Minimum delay between continues |
 | `--no-progress-threshold <n>` | Output token floor before pausing |
 | `--no-progress-turns <n>` | Consecutive stalled low-output turns before pausing |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Session-scoped /goal workflow for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -142,7 +142,7 @@ function formatStatus(goal) {
   const lines = [
     `Active goal: ${goal.condition}`,
     `Auto-continues sent: ${goal.turnCount}/${goal.options.maxTurns}`,
-    `Tokens: ${goal.totalTokens.toLocaleString()}/${goal.options.maxTokens.toLocaleString()}`,
+    `Context tokens: ${goal.totalTokens.toLocaleString()}/${goal.options.maxTokens.toLocaleString()}`,
     `Elapsed: ${elapsed}s/${Math.round(goal.options.maxDurationMs / 1000)}s`,
     `Last progress: ${lastProgress}`,
     `No-progress turns: ${goal.noProgressTurns}`,
@@ -168,7 +168,7 @@ function formatGoalResult(result) {
     `Last goal: ${result.condition}`,
     `State: ${result.state}`,
     `Auto-continues sent: ${result.turnCount}`,
-    `Tokens: ${result.totalTokens.toLocaleString()}`,
+    `Context tokens: ${result.totalTokens.toLocaleString()}`,
     `Elapsed: ${elapsed}s`,
     `Last checkpoint: ${lastCheckpoint}`,
     `Last status: ${result.lastStatus || "No status recorded."}`,
@@ -198,7 +198,7 @@ function stopReason(goal) {
   if (Date.now() - goal.startedAt >= goal.options.maxDurationMs) {
     return `max duration reached (${Math.round(goal.options.maxDurationMs / 1000)}s)`
   }
-  if (goal.totalTokens >= goal.options.maxTokens) return `max tokens reached (${goal.options.maxTokens})`
+  if (goal.totalTokens >= goal.options.maxTokens) return `max context tokens reached (${goal.options.maxTokens.toLocaleString()})`
   return null
 }
 
@@ -679,7 +679,7 @@ function buildLimitWarning(goal) {
     warnings.push(`${Math.max(0, Math.round(remainingMs / 1000))}s remaining`)
   }
   if (remainingTokens <= goal.options.warnTokensRemaining) {
-    warnings.push(`${Math.max(0, remainingTokens).toLocaleString()} tracked token(s) remaining`)
+    warnings.push(`${Math.max(0, remainingTokens).toLocaleString()} context token(s) remaining`)
   }
 
   return warnings.length ? ` Limits are near: ${warnings.join(", ")}.` : ""
@@ -711,8 +711,8 @@ function buildContinueMessage(goal, { budgetWrapup = false } = {}) {
     "<progress_budget>",
     `auto_continues_used: ${goal.turnCount}`,
     `auto_continues_remaining: ${remainingTurns}`,
-    `tracked_tokens_used: ${goal.totalTokens}`,
-    `tracked_tokens_remaining: ${remainingTokens}`,
+    `context_tokens_used: ${goal.totalTokens}`,
+    `context_tokens_remaining: ${remainingTokens}`,
     `elapsed_seconds: ${elapsedSeconds}`,
     "</progress_budget>",
     "",
@@ -721,7 +721,7 @@ function buildContinueMessage(goal, { budgetWrapup = false } = {}) {
   if (budgetWrapup) {
     lines.push(
       "<budget_wrapup>",
-      "This goal is near its tracked token limit. Finish the current step if it is small and safe.",
+      "This goal is near its context token limit. Finish the current step if it is small and safe.",
       "Then write a concise handoff summary covering what is done, what remains, and the next concrete command or file to inspect.",
       "Do not output [goal:complete] unless the goal is actually finished and verified.",
       "After the handoff, stop.",
@@ -1030,7 +1030,7 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
       pushHistory(
         goal,
         "set",
-        `Goal created with limits: ${goal.options.maxTurns} auto-continues, ${Math.round(goal.options.maxDurationMs / 1000)}s, ${goal.options.maxTokens.toLocaleString()} tracked tokens.`,
+        `Goal created with limits: ${goal.options.maxTurns} auto-continues, ${Math.round(goal.options.maxDurationMs / 1000)}s, ${goal.options.maxTokens.toLocaleString()} context tokens.`,
       )
 
       cleanupGoal(sessionID)
@@ -1049,7 +1049,7 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
             "",
             `Limits: ${goal.options.maxTurns} auto-continues, ${Math.round(
               goal.options.maxDurationMs / 1000,
-            )}s, ${goal.options.maxTokens.toLocaleString()} tracked tokens.`,
+            )}s, ${goal.options.maxTokens.toLocaleString()} context tokens.`,
           ].join("\n"),
         ),
       ]
@@ -1072,7 +1072,13 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
         const currentTokens = totalTokensForMessage(message)
         const previousTokens = seenTokens.get(currentMessageID) || 0
         if (currentTokens > previousTokens) {
-          goal.totalTokens += currentTokens - previousTokens
+          // Track the context window size (peak input+output+reasoning),
+          // not cumulative API token consumption. Each message's tokens
+          // include the full conversation context, so accumulating deltas
+          // across messages inflates the count by re-counting prior turns.
+          // Using Math.max gives the current context size, matching what
+          // OpenCode displays and making the budget check intuitive.
+          goal.totalTokens = Math.max(goal.totalTokens, currentTokens)
           seenTokens.set(currentMessageID, currentTokens)
           goal.messageIDs.add(currentMessageID)
           changed = true
@@ -1261,7 +1267,7 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
               activeGoalAfterPrompt,
               budgetWrapup ? "budget-wrapup" : "auto-continue",
               budgetWrapup
-                ? "Sent a final handoff request near the tracked token budget."
+                ? "Sent a final handoff request near the context token budget."
                 : `Sent auto-continue prompt ${activeGoalAfterPrompt.turnCount}/${activeGoalAfterPrompt.options.maxTurns}.`,
             )
           }

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -142,7 +142,7 @@ test("continue message includes budget context and completion audit", () => {
     options: normalizeOptions({ maxTokens: 100, maxTurns: 5 }),
   })
   assert.match(messageText, /<progress_budget>/)
-  assert.match(messageText, /tracked_tokens_remaining: 75/)
+  assert.match(messageText, /context_tokens_remaining: 75/)
   assert.match(messageText, /<completion_audit>/)
   assert.match(messageText, /treat completion as unproven/)
 })
@@ -600,6 +600,82 @@ test("non-assistant token updates count toward budget but do not reset progress"
   assert.equal(goal.lastProgressAt, 0)
 })
 
+test("token tracking uses context window size, not cumulative API consumption", async () => {
+  const { hooks } = await createHooks()
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-ctx", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const goal = currentGoal("session-ctx")
+
+  // First message: small context
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-1",
+          role: "assistant",
+          sessionID: "session-ctx",
+          tokens: { input: 5000, output: 1000, reasoning: 200 },
+        },
+      },
+    },
+  })
+  assert.equal(goal.totalTokens, 6200)
+
+  // Second message: context has grown (input includes prior turn)
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-2",
+          role: "assistant",
+          sessionID: "session-ctx",
+          tokens: { input: 7200, output: 1500, reasoning: 300 },
+        },
+      },
+    },
+  })
+  // totalTokens should be the peak context size (9000), NOT 6200+9000=15200
+  assert.equal(goal.totalTokens, 9000)
+
+  // Streaming update for same message grows tokens progressively
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-2",
+          role: "assistant",
+          sessionID: "session-ctx",
+          tokens: { input: 7200, output: 2000, reasoning: 300 },
+        },
+      },
+    },
+  })
+  assert.equal(goal.totalTokens, 9500)
+
+  // A smaller message should NOT shrink the context
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-3",
+          role: "user",
+          sessionID: "session-ctx",
+          tokens: { input: 3000, output: 50, reasoning: 0 },
+        },
+      },
+    },
+  })
+  // Math.max keeps the peak at 9500, not shrinking to 3050
+  assert.equal(goal.totalTokens, 9500)
+})
+
 test("parses --max-duration-ms flag directly", () => {
   const parsed = parseGoalArguments("fix tests --max-duration-ms 90000", normalizeOptions())
   assert.equal(parsed.condition, "fix tests")
@@ -757,7 +833,7 @@ test("formatStatus includes all key fields", () => {
   const status = formatStatus(goal)
   assert.match(status, /Active goal: ship it/)
   assert.match(status, /Auto-continues sent: 3\/10/)
-  assert.match(status, /Tokens:/)
+  assert.match(status, /Context tokens:/)
   assert.match(status, /Elapsed:/)
   assert.match(status, /Last progress:/)
   assert.match(status, /Recent checkpoint:/)
@@ -1625,7 +1701,7 @@ test("stopReason returns correct string for each limit type", () => {
   }
   assert.match(stopReason({ ...base, turnCount: 5 }), /max turns/)
   assert.match(stopReason({ ...base, turnCount: 4, startedAt: Date.now() - 70000 }), /max duration/)
-  assert.match(stopReason({ ...base, turnCount: 4, totalTokens: 1000 }), /max tokens/)
+  assert.match(stopReason({ ...base, turnCount: 4, totalTokens: 1000 }), /max context tokens/)
   assert.equal(stopReason({ ...base, turnCount: 4 }), null)
 })
 


### PR DESCRIPTION
## Summary

Fixes #5 — the reported token count was 5-10× higher than what OpenCode displays.

**Root cause:** The plugin accumulated `input + output + reasoning` deltas across all session messages in `message.updated` events. Since each message's `tokens.input` includes the full conversation context (all prior turns), accumulating deltas re-counted prior turns every time. In a 10-turn session, this could inflate `totalTokens` to 5-10× the actual context window size.

**Fix:** Changed `totalTokens` tracking from cumulative addition (`goal.totalTokens += delta`) to peak tracking (`goal.totalTokens = Math.max(goal.totalTokens, currentTokens)`). This makes the displayed token count match OpenCode's context display and makes the budget check intuitive (context window vs. limit).

### Changes

- **Core fix:** `goal.totalTokens` now uses `Math.max` instead of additive delta accumulation
- **Labels:** Renamed all user-facing strings from "tracked tokens" to "context tokens" for clarity
- **Continuation prompt:** `tracked_tokens_used`/`tracked_tokens_remaining` → `context_tokens_used`/`context_tokens_remaining`
- **Status display:** `Tokens:` → `Context tokens:`
- **Stop reason:** `max tokens reached` → `max context tokens reached`
- **README:** Updated token budget explanation to clarify it tracks context window size
- **Tests:** Added regression test verifying multi-message tracking doesn't accumulate across turns
- **Version:** Bumped to 0.1.10, added CHANGELOG entry

### Test Plan
- [x] All 49 existing tests pass
- [x] New test `token tracking uses context window size, not cumulative API consumption` verifies:
  - First message sets totalTokens to its context size
  - Second (larger) message updates totalTokens to the new peak (not the sum)
  - Streaming updates for the same message grow totalTokens progressively
  - A smaller message does NOT shrink totalTokens (Math.max preserves the peak)