### PR TITLE
fix: remove buildLimitWarning from system.transform to preserve provider prefix cache

### DIFF
--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -2776,13 +2776,21 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
       const systemBlocks = Array.isArray(output.system) ? [...output.system] : []
       if (systemBlocks.some(systemBlockContainsGoal)) return
 
+      // Only static content here — volatile fields (limit warnings, turn counters,
+      // token counts, wall-clock values) must not appear in the system prompt.
+      // system.transform fires on every provider request including tool-call
+      // sub-requests; any per-turn drift in the system prompt invalidates the
+      // provider-side prefix cache from byte 0, turning O(1) cache hits into
+      // O(N*turns) full-context misses. Limit warnings are already delivered
+      // on every continuation turn via buildContinueMessage (buildLimitWarning
+      // and <progress_budget>), which is sufficient — the model doesn't need
+      // them in the system prompt mid-turn.
       const goalBlock = [
         buildGoalBlock(goal),
         "Keep working until the goal is fully satisfied.",
         "When fully satisfied, put a `[goal:evidence]` line summarizing what you verified immediately before `[goal:complete]`. A `[goal:complete]` without evidence is rejected.",
         "If user input is required, explain the concrete blocker in the line immediately before `[goal:blocked]`. A `[goal:blocked]` without a concrete blocker is rejected.",
-        buildLimitWarning(goal),
-      ].filter(Boolean).join("\n")
+      ].join("\n")
 
       if (systemBlocks.length === 0) {
         output.system = [goalBlock]

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -1863,6 +1863,54 @@ test("buildLimitWarning reports remaining seconds when duration is nearly exhaus
   assert.match(warning, /s remaining/)
 })
 
+test("system transform output is byte-stable across turns even when limit thresholds are crossed", async () => {
+  // Regression test for issue #13: buildLimitWarning was injected into the
+  // system prompt via system.transform, making the system prompt volatile once
+  // any warning threshold was crossed. system.transform fires on every provider
+  // request including tool-call sub-requests; volatile content there invalidates
+  // the provider-side prefix cache from byte 0 on every sub-request, causing
+  // O(turns * tool_calls) full-context cache misses. The fix: only static
+  // content in the system prompt. Limit warnings live in buildContinueMessage.
+  const { hooks } = await createHooks()
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-cache-stable", arguments: "implement the feature" },
+    { parts: [] },
+  )
+
+  const goal = currentGoal("session-cache-stable")
+
+  // Put the goal near its limits so buildLimitWarning would previously have fired
+  // (warnTurnsRemaining=3 → fires when turnCount >= maxTurns - 3 = 7)
+  // (warnTokensRemaining=25000 → fires when totalTokens >= maxTokens - 25000 = 175000)
+  goal.turnCount = 8
+  goal.totalTokens = 180_000
+
+  const output1 = { system: [] }
+  await hooks["experimental.chat.system.transform"]({ sessionID: "session-cache-stable" }, output1)
+  const snapshot1 = output1.system[0]
+
+  // Advance counters further (different turn, different remaining tokens)
+  goal.turnCount = 9
+  goal.totalTokens = 195_000
+
+  const output2 = { system: [] }
+  await hooks["experimental.chat.system.transform"]({ sessionID: "session-cache-stable" }, output2)
+  const snapshot2 = output2.system[0]
+
+  assert.equal(
+    snapshot1,
+    snapshot2,
+    "system transform must produce byte-identical output across turns — any per-turn drift invalidates the provider prefix cache",
+  )
+
+  // Also confirm the goal objective is present (sanity)
+  assert.match(snapshot1, /<goal_objective>\nimplement the feature\n<\/goal_objective>/)
+
+  // And confirm no limit-warning text leaked into the system prompt
+  assert.doesNotMatch(snapshot1, /Limits are near/)
+  assert.doesNotMatch(snapshot2, /Limits are near/)
+})
+
 test("duration limit requests a final handoff and stops the goal", async () => {
   const { calls, hooks } = await createHooks({
     options: { minDelayMs: 1, maxDurationMs: 10_000, noProgressTokenThreshold: 1 },


### PR DESCRIPTION
## What changed

Removed `buildLimitWarning(goal)` from the `goalBlock` array inside `experimental.chat.system.transform` (one-line removal). The `.filter(Boolean)` call is also removed since there are no longer conditional elements.

## Why it changed

Fixes #13. `system.transform` fires on **every** OpenCode provider request, including tool-call sub-requests within a single semantic turn. `buildLimitWarning` injected volatile fields into the system prompt:

- `remainingTurns` — decrements each turn
- `remainingMs` — derived from `Date.now()`, changes every millisecond
- `remainingTokens` — decrements as context grows

Once any warning threshold was crossed (token threshold at `maxTokens - warnTokensRemaining = 175k` for default config), every sub-request got a different system-prompt hash → provider prefix cache invalidated from byte 0 → full 200k context re-processed at cache-miss rates on every tool-call sub-request. With a thinking model making 10+ tool calls per turn and the threshold firing at turn 5–6, cost scaled as `O(turns × tool_calls × context_size)` instead of `O(turns × continuation_message_size)`. Reported impact: ~$12 in 8 minutes on DeepSeek with 200k context.

Limit warnings are already delivered to the model on every continuation turn via `buildContinueMessage` (line 1307), which already called `buildLimitWarning`. The model receives warnings where they matter — at the start of each new turn — without paying a per-sub-request cache-invalidation tax. The system prompt now contains only `buildGoalBlock` (stable per session) and three static instruction strings.

## Checks run

```
npm test          # 146/146 pass (includes new regression test)
npm run smoke     # passed
npm run check     # passed
```

New regression test: "system transform output is byte-stable across turns even when limit thresholds are crossed" — sets `turnCount=8, totalTokens=180_000` (both warning-threshold-crossing values), calls `system.transform` twice with different counters, and asserts byte-identical output with no "Limits are near" text.

## Manual OpenCode smoke testing

Not performed (no model invocation needed to verify the invariant — the regression test confirms byte-stability directly).