### PR TITLE
fix: cap consecutive format-validation re-prompts via formatFailures counter

### DIFF
--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -520,6 +520,7 @@ function resetGoalBudget(goal) {
   goal.budgetWrapupSent = false
   goal.messageIDs = new Set()
   goal.promptFailures = 0
+  goal.formatFailures = 0
   goal.lastAssistantMessageID = ""
   goal.history = [...(goal.history || [])].slice(-MAX_HISTORY_ENTRIES)
 }
@@ -1583,6 +1584,7 @@ function buildGoalState(sessionID, condition, options, meta = {}, lastStatus = "
     stopped: false,
     stopReason: "",
     promptFailures: 0,
+    formatFailures: 0,
     messageIDs: new Set(),
     history: [],
     checkpoints: [],
@@ -2694,13 +2696,34 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
         activeGoalBeforePrompt.lastContinueAt = Date.now()
         if (!budgetWrapup) {
           if (completionUnverified) {
+            activeGoalBeforePrompt.formatFailures += 1
             activeGoalBeforePrompt.lastStatus = `Rejected an unverified [goal:complete] (no [goal:evidence]); re-prompting for evidence on turn ${activeGoalBeforePrompt.turnCount}.`
           } else if (blockerUnstated) {
+            activeGoalBeforePrompt.formatFailures += 1
             activeGoalBeforePrompt.lastStatus = `Rejected a [goal:blocked] with no concrete blocker; re-prompting on turn ${activeGoalBeforePrompt.turnCount}.`
           } else {
+            activeGoalBeforePrompt.formatFailures = 0
             activeGoalBeforePrompt.lastStatus = latestText
               ? `Continuing after assistant turn ${activeGoalBeforePrompt.turnCount}.`
               : `Continuing after idle event ${activeGoalBeforePrompt.turnCount}.`
+          }
+
+          // Pause after too many consecutive format-validation failures. Unlike
+          // promptFailures (which counts network/protocol errors), this counts turns
+          // where the model signalled completion or a blocker but omitted the required
+          // evidence or concrete-blocker line. The same maxPromptFailures cap applies;
+          // resume resets the counter via resetGoalBudget.
+          if (activeGoalBeforePrompt.formatFailures >= activeGoalBeforePrompt.options.maxPromptFailures) {
+            activeGoalBeforePrompt.stopped = true
+            activeGoalBeforePrompt.stopReason = "format validation failures"
+            activeGoalBeforePrompt.lastStatus = `Paused after ${activeGoalBeforePrompt.formatFailures} consecutive format-validation failure(s) (missing [goal:evidence] or concrete blocker). Run /${commandName} resume to retry.`
+            pushHistory(
+              activeGoalBeforePrompt,
+              "paused",
+              `Paused after ${activeGoalBeforePrompt.formatFailures} consecutive format-validation failure(s).`,
+            )
+            await persist()
+            return
           }
         }
 

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -1613,6 +1613,94 @@ test("[goal:blocked] without a concrete blocker is rejected and continues", asyn
   assert.match(calls[0].body.parts[0].text, /no concrete blocker/)
 })
 
+test("repeated [goal:complete]-without-evidence re-prompts pause the goal after maxPromptFailures", async () => {
+  // Regression: completionUnverified re-prompts never counted toward promptFailures,
+  // so a model that consistently omits [goal:evidence] would loop until a hard limit.
+  // formatFailures counter now caps this at maxPromptFailures consecutive format failures.
+  const { calls, hooks } = await createHooks({
+    messages: async () => ({ data: [message("All done!\n\n[goal:complete]")] }),
+    options: { minDelayMs: 1, maxPromptFailures: 2 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-fmt-complete", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const fireIdle = () =>
+    hooks.event({
+      event: { type: "session.status", properties: { sessionID: "session-fmt-complete", status: { type: "idle" } } },
+    })
+
+  await fireIdle() // formatFailures → 1; re-prompt sent
+  const goal = currentGoal("session-fmt-complete")
+  assert.equal(goal.stopped, false, "should still be running after first format failure")
+  assert.equal(goal.formatFailures, 1)
+  assert.equal(calls.length, 1)
+  assert.match(calls[0].body.parts[0].text, /<evidence_required>/)
+
+  await fireIdle() // formatFailures → 2 >= maxPromptFailures; goal paused, no extra call
+  assert.equal(goal.stopped, true)
+  assert.equal(goal.stopReason, "format validation failures")
+  assert.match(goal.lastStatus, /format-validation failure/)
+  assert.equal(calls.length, 1, "no additional promptAsync call after pause")
+})
+
+test("repeated [goal:blocked]-without-blocker re-prompts pause the goal after maxPromptFailures", async () => {
+  const { calls, hooks } = await createHooks({
+    messages: async () => ({ data: [message("[goal:blocked]")] }),
+    options: { minDelayMs: 1, maxPromptFailures: 2 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-fmt-blocked", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const fireIdle = () =>
+    hooks.event({
+      event: { type: "session.status", properties: { sessionID: "session-fmt-blocked", status: { type: "idle" } } },
+    })
+
+  await fireIdle() // formatFailures → 1
+  assert.equal(currentGoal("session-fmt-blocked").stopped, false)
+  assert.equal(calls.length, 1)
+
+  await fireIdle() // formatFailures → 2 >= maxPromptFailures; pause
+  const goal = currentGoal("session-fmt-blocked")
+  assert.equal(goal.stopped, true)
+  assert.equal(goal.stopReason, "format validation failures")
+  assert.equal(calls.length, 1)
+})
+
+test("formatFailures resets to zero when the model produces a valid response", async () => {
+  let turnCount = 0
+  const { calls, hooks } = await createHooks({
+    messages: async () => {
+      turnCount += 1
+      // Turn 1: invalid (no evidence); Turn 2: valid response
+      return {
+        data: [turnCount < 2 ? message("All done!\n\n[goal:complete]") : message("Still working on it.")],
+      }
+    },
+    options: { minDelayMs: 1, maxPromptFailures: 3 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-fmt-reset", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const fireIdle = () =>
+    hooks.event({
+      event: { type: "session.status", properties: { sessionID: "session-fmt-reset", status: { type: "idle" } } },
+    })
+
+  await fireIdle() // turn 1: completionUnverified → formatFailures = 1
+  assert.equal(currentGoal("session-fmt-reset").formatFailures, 1)
+
+  await fireIdle() // turn 2: valid response → formatFailures resets to 0
+  assert.equal(currentGoal("session-fmt-reset").formatFailures, 0)
+  assert.equal(currentGoal("session-fmt-reset").stopped, false)
+})
+
 test("/goal clear removes completed goal status", async () => {
   const { hooks } = await createHooks({
     messages: async () => ({ data: [message("All done!\n[goal:evidence] ran npm test, 83 pass\n[goal:complete]")] }),


### PR DESCRIPTION
## What changed

- Added `formatFailures: 0` field to goal state in `buildGoalState`
- Added `goal.formatFailures = 0` to `resetGoalBudget` (called on `/goal resume`)
- In the idle handler, `formatFailures` is incremented on each `completionUnverified` or `blockerUnstated` re-prompt, reset to 0 on any normal continuation turn, and checked against `maxPromptFailures` before sending the next re-prompt — pausing the goal if the limit is reached

## Why it changed

`completionUnverified` (model outputs `[goal:complete]` without `[goal:evidence]`) and `blockerUnstated` (model outputs `[goal:blocked]` without a concrete blocker line) triggered re-prompts that never incremented `promptFailures`, which only counted network/protocol errors from `promptAsync`. There was no cap on consecutive format-validation failures, so a model that consistently omitted the required marker lines would be re-prompted indefinitely until `maxTurns`, `maxDurationMs`, or `maxTokens` fired — consuming the entire budget on repeated identical corrective messages.

The fix reuses `maxPromptFailures` (default 3) as the cap. After 3 consecutive format-validation failures, the goal pauses with `stopReason: "format validation failures"`. Resuming via `/goal resume` resets the counter (same as `promptFailures` via `resetGoalBudget`).

## Checks run

```
npm test          # 148/148 pass (includes 3 new tests)
npm run smoke     # passed
npm run check     # passed
```

New tests:
- "repeated [goal:complete]-without-evidence re-prompts pause the goal after maxPromptFailures"
- "repeated [goal:blocked]-without-blocker re-prompts pause the goal after maxPromptFailures"
- "formatFailures resets to zero when the model produces a valid response"

## Manual OpenCode smoke testing

Not performed.