### PR TITLE
fix: exclude tool-calling turns from noProgress stall detection

### DIFF
--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -2600,12 +2600,23 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
           return
         }
 
+        // Hoist tool-call check so both the noProgress and noToolCall gates can
+        // use it. A tool call is evidence of real work even when prose output
+        // is tiny (e.g. a thinking model that calls a tool with < 50 output
+        // tokens), so it resets noProgressTurns the same way the noToolCall
+        // gate already resets noToolCallTurns.
+        const latestHasToolCall = messageHasToolCall(latestAssistant)
+
         const lowOutputTurn =
           activeGoalAfterMessages.turnCount > 0 &&
           latestOutputTokens !== null &&
           latestOutputTokens < activeGoalAfterMessages.options.noProgressTokenThreshold
+        // A turn that used a tool is never stalled even with low output tokens:
+        // reasoning-heavy models often produce small prose output while doing
+        // real work via tool calls. Excluding tool-call turns prevents false
+        // noProgress pauses on thinking models.
         const lowOutputLooksStalled =
-          lowOutputTurn && (assistantRepeated || !latestText || !assistantChanged)
+          lowOutputTurn && !latestHasToolCall && (assistantRepeated || !latestText || !assistantChanged)
         if (lowOutputLooksStalled) {
           activeGoalAfterMessages.noProgressTurns += 1
           if (
@@ -2640,7 +2651,6 @@ export const GoalPlugin = async ({ client }, pluginOptions = {}) => {
         // configured grace window. Complements the low-output check above:
         // a turn can be high-output yet still make no real progress because it
         // never touched a tool.
-        const latestHasToolCall = messageHasToolCall(latestAssistant)
         const noToolCallContinuation =
           activeGoalAfterMessages.turnCount > 0 && Boolean(latestAssistant) && !latestHasToolCall
         if (noToolCallContinuation) {

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -811,6 +811,54 @@ test("short assistant updates that change content do not immediately count as st
   assert.equal(currentGoal("session-changing").noProgressTurns, 0)
 })
 
+test("tool-calling turns with low output tokens are not counted as stalled", async () => {
+  // Regression: lowOutputLooksStalled fired when output < noProgressTokenThreshold AND
+  // latestText was empty, even if the turn used tool calls. Thinking models often call
+  // tools with very little prose output (< 50 tokens, no text body), so two consecutive
+  // such turns would incorrectly pause the goal. The fix: !latestHasToolCall is now
+  // a required condition for lowOutputLooksStalled.
+  let callCount = 0
+  const { calls, hooks } = await createHooks({
+    messages: async () => {
+      callCount += 1
+      return {
+        data: [
+          {
+            info: {
+              id: `msg-tool-${callCount}`,
+              role: "assistant",
+              sessionID: "session-tool-stall",
+              tokens: { input: 1, output: 5, reasoning: 50000 },
+            },
+            // No prose body — pure tool call with only reasoning tokens.
+            parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
+          },
+        ],
+      }
+    },
+    options: { minDelayMs: 1, noProgressTokenThreshold: 50, noProgressTurnsBeforePause: 2 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-tool-stall", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const fireIdle = () =>
+    hooks.event({
+      event: { type: "session.status", properties: { sessionID: "session-tool-stall", status: { type: "idle" } } },
+    })
+
+  await fireIdle()
+  await fireIdle()
+
+  // Despite two consecutive turns with < 50 output tokens and no prose, the goal
+  // must NOT be paused because each turn called a tool.
+  const goal = currentGoal("session-tool-stall")
+  assert.equal(goal.stopped, false, "tool-using turns must not trigger noProgress pause")
+  assert.equal(goal.noProgressTurns, 0, "noProgressTurns must stay 0 when tool calls are present")
+  assert.equal(calls.length, 2)
+})
+
 test("missing recent assistant message does not trigger a false no-progress stop", async () => {
   const calls = []
   const client = {


### PR DESCRIPTION
## What changed

- Hoisted `const latestHasToolCall = messageHasToolCall(latestAssistant)` above the `noProgressTurns` block (it was previously declared only in the no-tool-call gate below)
- Added `!latestHasToolCall` as a required condition in `lowOutputLooksStalled`

```js
// Before
const lowOutputLooksStalled =
  lowOutputTurn && (assistantRepeated || !latestText || !assistantChanged)

// After
const lowOutputLooksStalled =
  lowOutputTurn && !latestHasToolCall && (assistantRepeated || !latestText || !assistantChanged)
```

## Why it changed

Thinking models (DeepSeek R1, o3, etc.) routinely call tools with very little prose output — reasoning tokens absorb the work, and the text body of the assistant turn may be empty with fewer than 50 output tokens. Two consecutive such turns would satisfy `lowOutputLooksStalled` (low output + no prose text) and pause the goal with `stopReason: "no progress"`, even though the model was actively using tools.

A turn that called a tool is evidence of real work regardless of prose output count. Excluding tool-calling turns from stall detection is consistent with how `noToolCallTurns` already works: `noToolCallTurns` is reset when `latestHasToolCall` is true, so `noProgressTurns` should be as well.

## Checks run

```
npm test          # 146/146 pass (includes 1 new test)
npm run smoke     # passed
npm run check     # passed
```

New test: "tool-calling turns with low output tokens are not counted as stalled" — two consecutive tool-only turns with 5 output tokens and 50k reasoning tokens each must not pause the goal; `noProgressTurns` stays 0.

## Manual OpenCode smoke testing

Not performed.