### PR TITLE
fix: improve completion marker compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Clarify the textual completion protocol so models keep evidence and completion on consecutive plain-text lines instead of wrapping markers in Markdown or separating them with blank lines.
+
 ## 0.6.2 — 2026-07-11
 
 - Keep paused, blocked, and crash-recovered goals inert in model turns with a stopped-goal system guard, and enforce status/history/list/pause/clear control turns as read-only through the host's tool-execution hook so routed command text cannot mutate or resurrect work.

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -1756,11 +1756,16 @@ function buildContinueMessage(
     )
   } else {
     lines.push(
-      "Continue with the next concrete step; inspect current state and repair failures.",
+      "Continue the next concrete step; inspect and repair failures.",
     )
   }
 
-  lines.push("Complete only after verification: `[goal:evidence] …` then `[goal:complete]`. If only user input can unblock work, state why then `[goal:blocked]`.")
+  lines.push(
+    "Completion format—consecutive plain lines; no Markdown/backticks/blank line:",
+    "[goal:evidence] <proof>",
+    "[goal:complete]",
+    "Need user input? State why before [goal:blocked].",
+  )
   const limitWarning = buildLimitWarning(goal)
   if (limitWarning) lines.push(limitWarning.trim())
 

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -409,8 +409,15 @@ test("continue message includes budget context and completion audit", () => {
   })
   assert.match(messageText, /<progress_budget>/)
   assert.match(messageText, /tokens_remaining: 75/)
-  assert.match(messageText, /Complete only after verification/)
-  assert.match(messageText, /\[goal:evidence\].*\[goal:complete\]/)
+  assert.match(messageText, /Completion format/)
+  assert.match(
+    messageText,
+    /consecutive plain lines; no Markdown\/backticks\/blank line/,
+  )
+  assert.match(
+    messageText,
+    /\[goal:evidence\] <proof>\n\[goal:complete\]/,
+  )
   assert.match(messageText, /Limits are near:/)
 })
 


### PR DESCRIPTION
## Summary

Improve textual completion-marker compliance without loosening the strict detector or adjacent-evidence gate.

## Changes

- show `[goal:evidence]` and `[goal:complete]` as consecutive plain-text lines in the continuation prompt
- explicitly prohibit Markdown/backtick wrapping and blank-line separation
- keep normal and budget-wrapup continuation prompts within their existing size limits
- add focused regression assertions and an Unreleased changelog entry

## Evidence

A real-provider prompt matrix reproduced common failures with the previous wording: only 2/10 models produced evidence and completion accepted by the production parser. A longer candidate improved this to 8/10. The final compact worktree wording produced canonical adjacent protocol lines in all seven targeted baseline-failure models.

The marker detector and evidence extractor are unchanged.

## Testing

- `npm test` — 249/249 pass
- `npm run release:check` — pass
- coverage — 98.47% lines / 90.50% branches / 89.98% functions
- type contract — NodeNext + Bundler pass
- mutation contract — 5/5 critical mutants killed
- behavior benchmark — 100/100
- packed host/tool contracts — pass, exact 11-tool surface
- installer verifier — 6/6, all 7 hooks
- production dependency audit — 0 vulnerabilities
- provider validation — canonical adjacent completion protocol in 7/7 targeted models

## Checklist

- [x] Tests added/updated
- [x] Changelog updated
- [x] No parser relaxation
- [x] No breaking API changes
- [x] Full local release gate passes
