### PR TITLE
chore: prepare v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.3 — 2026-07-11
+
 - Clarify the textual completion protocol so models keep evidence and completion on consecutive plain-text lines instead of wrapping markers in Markdown or separating them with blank lines.
 
 ## 0.6.2 — 2026-07-11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "bin": {
         "opencode-goal-plugin": "scripts/verify.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
## Summary

- bump the package version from 0.6.2 to 0.6.3
- add the 0.6.3 changelog entry for the completion-protocol prompt hardening
- keep completion detection strict; no detector broadening was warranted by the provider evidence

## Verification

- `npm run release:check`
- 249/249 tests passed
- type checks passed in NodeNext and Bundler modes
- mutation, behavior, packed-host, tool-contract, verifier, audit, and pack dry-run gates passed
- `npm audit`: 0 vulnerabilities

This PR contains only `CHANGELOG.md`, `package.json`, and `package-lock.json` release metadata.