### PR TITLE
chore(release): 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.5 — 2026-07-12
 
 - Make `/goal sequence` the canonical ordered multi-goal command, retain the previous command and mode spelling as input-only compatibility aliases, correct the public auditor snapshot mode type to `"normal" | "ordered"`, and align README archive and compatibility claims with verified behavior.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "bin": {
         "opencode-goal-plugin": "scripts/verify.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
## Summary

- bump `package.json` and `package-lock.json` from 0.6.4 to 0.6.5
- promote the existing Unreleased changelog entry to `0.6.5`
- publish the already-merged canonical `/goal sequence` command and corrected auditor snapshot mode type in the next npm artifact

No source changes are introduced by this PR; the implementation was reviewed and merged in #33.

## Testing

- `npm run release:check`
- 263/263 tests passed
- 98.41% line / 90.25% branch / 90.44% function coverage
- strict NodeNext and Bundler type contracts passed
- 5/5 critical mutants killed
- behavior benchmark: 100/100
- smoke, packed-host, packed-tools, verifier, production dependency audit, and pack dry-run passed

## Compatibility

The previous `sisyphus` command and `--mode=sisyphus` inputs remain supported as compatibility aliases. No persisted-state migration is required.