### PR TITLE
chore(release): 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.6 — 2026-07-29
 
 - Shard persisted goal state and lifecycle ledgers by hashed OpenCode session ID so independent sessions can run concurrently in one project. Keep same-session single-writer leases, lazy session loading, crash recovery, and safe migration of aggregate, legacy, and XDG state.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "bin": {
         "opencode-goal-plugin": "scripts/verify.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
## Summary

Release the concurrent-session persistence work from PR #39 as `opencode-goal-plugin@0.6.6`.

## Changes

- bump `package.json` and `package-lock.json` from 0.6.5 to 0.6.6
- date the existing changelog entry as `0.6.6 — 2026-07-29`
- keep the release commit limited to those three metadata files

## Impact

Independent OpenCode sessions in one project can persist goals and lifecycle ledgers concurrently through session-sharded state, while preserving same-session single-writer leases, lazy loading, crash recovery, and migration of aggregate, legacy, and XDG state.

## Validation

- `npm ci` — 0 vulnerabilities
- `npm run release:check` — passed
  - 268/268 tests
  - type contract passed
  - 5/5 critical mutation contracts killed
  - behavior benchmark 100/100
  - source, packed-host, and packed-tools smoke checks passed
  - installation verifier 6/6
  - production audit: 0 vulnerabilities
  - package dry run: 24 files
- inspected local tarball: 94,525 bytes
- local tarball SHA-256: `26c855e1e1fcb45b473acc5789fa65853f4369f70daa8dd7de7d4f145a304022`

## Checklist

- [x] Version metadata updated together
- [x] Changelog dated
- [x] Full local release gate passed
- [x] Package contents inspected
- [x] No breaking API change