### PR TITLE
chore(release): 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.7 — 2026-08-01
 
 - Fix `/goal` routing on OpenCode 1.17.15 and 1.18.10 by replacing the host-retained prompt parts in place, authenticating each resolved command turn (including host-expanded file attachments), framing control results with direct reporting instructions, blocking tools during those reporting turns, and excluding control responses from goal completion and progress analysis. Unreadable command attachments now become read-only error reports and pause safely without losing command provenance.
 - Register all 11 agent-facing goal tools in a standard clean install through the package's direct Zod dependency; a separate optional `@opencode-ai/plugin` install is no longer required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "zod": "4.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
## Summary

Release the command-routing and clean-install tool-registration fixes from #43 as `opencode-goal-plugin@0.6.7`.

## Changes

- bump `package.json` and `package-lock.json` from 0.6.6 to 0.6.7
- date the existing changelog entries as `0.6.7 — 2026-08-01`
- keep the release commit limited to those three metadata files

No source or README changes are introduced by this PR; the implementation was reviewed and merged in #43.

## Impact

OpenCode 1.17.15 and 1.18.10 now route `/goal` control commands deterministically, including attachment and overlapping-turn cases. Standard clean installs expose all 11 goal tools.

## Validation

- `npm ci` — passed; 3 packages audited, 0 vulnerabilities
- `npm run release:check` — passed on this exact release tree
  - 287/287 assertions
  - 23/23 critical mutants killed
  - behavior benchmark 100/100
  - 98.36% lines, 89.84% branches, 89.27% functions
  - NodeNext/Bundler types, packed-host, packed-tool, verifier, audit, and package gates passed
  - all 11 tools registered in the packed clean-install contract
- exact issue-fix merge CI and CodeQL — 11/11 checks passed
- real-host acceptance passed on OpenCode 1.17.15 and 1.18.10
- Debian 13.6 / Node 22.23.2 / OpenCode 1.18.10 acceptance passed
- local inspection tarball: 24 files, 100,514 bytes, SHA-256 `8d17badf4d2367cb9d64e13504d2c5a58b42fb22c150c828d0f706431eccadd0`
- exact packed source SHA-256: `d9225e2ea609db69cdf562ab457af5f9f603a999cca340f2e7bc8f9f4629ff63`

The local tarball is inspection evidence only. After merge, tag the release PR merge commit and publish only the exact tarball retained by the tag-triggered Release check.

## Checklist

- [x] Version metadata updated together
- [x] Changelog dated
- [x] Full local release gate passed
- [x] Package contents and clean install inspected
- [x] No source or breaking API change
