### PR TITLE
chore(release): 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.8 — 2026-08-01
 
 - Keep a second OpenCode process usable when it opens a session whose goal-state shard is already leased: ordinary chat and unrelated tools remain available, while goal commands and tools fail safely without reading, changing, or prompting from that session's goal state. After the owner exits, the next explicit goal command or tool retries ownership and reloads any active goal paused. Lease contention is now typed and owner metadata is sanitized; unrelated filesystem failures still fail closed.
 - Harden the single-writer lease with immutable per-owner claims so delayed publication, simultaneous stale reclaim, and concurrent release cannot remove a replacement owner's lease. A complete compatibility guard is published atomically with no replacement, preventing old/current startup races; legacy, incomplete, tampered, or unsupported lease layouts fail closed for explicit manual recovery. Owner reads remain bounded and symlink-safe, slow passive command guards keep blocking tools until an authenticated new boundary, delayed control errors cannot pause a newer goal run, takeover retains Plan/model execution context, and advisory host logging cannot stall loading or disposal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "zod": "4.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
## Summary

Prepare `opencode-goal-plugin@0.6.8` for the same-session process-contention
fix merged in #46 (issue #41).

## Changes

- bump `package.json` and `package-lock.json` from 0.6.7 to 0.6.8
- date the existing issue #41 changelog entries as `0.6.8 — 2026-08-01`
- keep the release commit limited to those three metadata files

No source or README change is introduced by this PR. The implementation,
documentation, and tests were reviewed and merged in #46.

## Impact

- A second OpenCode process opening the same session remains usable for
  ordinary chat and unrelated tools instead of failing plugin initialization.
- Goal commands, goal tools, persistence, and auto-continuation stay safely
  passive while another process owns that session shard.
- A fresh explicit goal command or tool can take ownership after the owner
  exits and reload the recovered goal paused.
- Immutable owner claims and an atomic compatibility guard prevent stale
  cleanup, simultaneous reclaim, delayed publication, and mixed-version
  startup races from creating two owners or deleting a replacement lease.

## Validation

- `npm ci` — passed; 3 packages audited, 0 vulnerabilities
- `npm run release:check` — passed
  - 329/329 tests
  - 64/64 critical mutants killed
  - behavior benchmark 100/100
  - 98.35% line, 90.41% branch, and 89.22% function coverage
  - type, source smoke, packed-host, packed-tool, verifier, production audit,
    and package-content gates passed
- exact issue-fix merge CI and CodeQL passed on Linux, macOS, and Windows
- real OpenCode acceptance passed on 1.17.15 and 1.18.11
- reviewed local package: 24 files, 109,706 bytes packed, SHA-256
  `a0679f0669fa3bdddeb0b0196bb4cf0e0e002a45b0e55c7a255a0bd1e1dd16f7`
- clean consumer installation, six-check verifier, and public root/server
  imports passed from that exact tarball

## Checklist

- [x] Version metadata updated together
- [x] Changelog dated without rewriting the reviewed entries
- [x] Full local release gate passed
- [x] Exact tarball contents and installed behavior inspected
- [x] No source, README, or breaking API change in this release commit

