### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.8.0 — 2026-08-06
+
+Both new options in this release were contributed by
+[@harryzhou2000](https://github.com/harryzhou2000) in
+[#53](https://github.com/willytop8/OpenCode-goal-plugin/pull/53).
+
 - Add `noInterruptOnUserMessage` plugin option. When `true`, a new human message steers an active goal — the loop keeps running and the message is included in the next continuation — instead of pausing it with `stopReason: "user intervention"`. The pause-on-intervention default is unchanged.
 - Add `noContinueWhileChildrenActive` plugin option. When `true`, auto-continue is deferred while the session has active child sessions (subagents, background tasks), so the goal loop does not prompt the orchestrator over work a child is already doing; the goal stays running and continues on a later idle once the children finish. A child counts as active only while the host reports a non-idle status for it. Each deferral episode records a `deferred` history event and a status line so `/goal status` distinguishes "waiting on a subagent" from a hung loop. A deferred goal is re-driven by the child's own idle event, since a parent that is already idle emits no event of its own while a child runs. Hosts that cannot report children/status, and sessions with more concurrent children than the plugin can track, fail open and log once per plugin instance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "zod": "4.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
Version bump and changelog for 0.8.0.

Contents since 0.7.0 — two new opt-in plugin options, both defaulting to `false`, contributed by @harryzhou2000 in #53, plus follow-up hardening of the second one in #54.

Shipped files changed since v0.7.0:

| File | Change |
| --- | --- |
| `src/goal-plugin.js` | +367 (the two options, then the children-gate hardening) |
| `src/opencode-session-api.js` | +8 (`children`/`status` marked replay-safe) |
| `index.d.ts` | +19 (types for the two options) |
| `README.md` | +6 (docs) |

`npm run release:check` passes end to end:

- 384/384 tests, 98.44% lines / 90.91% branches
- type contract (NodeNext + Bundler)
- 67/67 critical mutants killed
- behavior benchmark, source and packed-artifact smokes, clean-install tool registration
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- packs as `opencode-goal-plugin-0.8.0.tgz`

Also verified locally on Node 18.20.8, 20.20.2, 22.22.3 and 24.19.0.