### PR TITLE
fix(goal-loop): resume auto-continue after session compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fix goal auto-continue stalling after session compaction: a continuation
+  claim for a pre-compaction source turn could match the still-visible tail
+  assistant message after compaction and suppress the post-compaction
+  continuation until the user nudged the goal. The claim is now invalidated on
+  `session.compacted`, so the loop resumes on the next idle.
+
 ## 0.8.0 — 2026-08-06
 
 Both new options in this release were contributed by

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -5331,6 +5331,12 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         if (!goal) return
         goal.messageIDs = new Set()
         goal.totalTokens = 0
+        // Compaction rewrites the context: a continuation claim for a
+        // pre-compaction source turn must not suppress the post-compaction
+        // continuation (the recent tail can still end on the same assistant
+        // message, which would otherwise stall the goal loop until the user
+        // nudges it).
+        goal.continuationClaim = null
         await persist(sessionID)
         return
       }

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -4363,6 +4363,49 @@ test("totalTokens resets to zero after session compaction", async () => {
   assert.equal(currentGoal(session).totalTokens, 45_000, "post-compaction tokens accumulate from zero")
 })
 
+test("auto-continue fires after compaction despite a pre-compaction continuation claim", async () => {
+  const calls = []
+  const client = {
+    app: { log: async () => {} },
+    session: {
+      messages: async () => ({
+        data: [pluginContinuationMessage(), message("did a step")],
+      }),
+      promptAsync: async (input) => {
+        calls.push(input)
+        return {}
+      },
+    },
+  }
+  const hooks = await GoalPlugin(
+    { client },
+    { persistState: false, minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  )
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-1", arguments: "ship it" },
+    { parts: [] },
+  )
+  const goal = currentGoal("session-1")
+  goal.turnCount = 1
+  goal.lastContinueAt = Date.now() - 10
+  // A continuation was claimed for the latest assistant turn right before the
+  // compaction interrupted it; after compaction the recent tail still ends on
+  // that same assistant message, so the stale claim must not suppress the
+  // post-compaction continuation.
+  goal.continuationClaim = { runId: goal.runId, sourceAssistantMessageID: "msg-assistant" }
+
+  await hooks.event({
+    event: { type: "session.compacted", properties: { sessionID: "session-1" } },
+  })
+
+  await hooks.event({
+    event: { type: "session.status", properties: { sessionID: "session-1", status: { type: "idle" } } },
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(currentGoal("session-1").stopped, false)
+})
+
 test("parses --max-duration-ms flag directly", () => {
   const parsed = parseGoalArguments("fix tests --max-duration-ms 90000", normalizeOptions())
   assert.equal(parsed.condition, "fix tests")


### PR DESCRIPTION
## What changed

Fixes the goal loop stalling after session compaction: auto-continue now resumes on the next idle instead of waiting for a user nudge.

Root cause: `claimContinuationSource` dedupes continuations by claiming the source assistant turn it continues from. When a compaction interrupts an in-flight continuation, the recent message tail can still end on that same pre-compaction assistant message, so after compaction the claim matched again and the idle driver returned early forever — the goal stayed "running" but never continued.

Fix: the `session.compacted` handler now invalidates `goal.continuationClaim`, so the post-compaction idle issues a fresh continuation against the compacted context (the claim's dedupe purpose does not apply across a compaction boundary).

## Why

The plugin disables OpenCode's generic post-compaction auto-continue while a goal is active (`experimental.compaction.autocontinue` → `enabled: false`) to avoid two continuations racing, and relies on its own idle-triggered loop instead. That handoff broke when the stale claim survived the compaction.

## Checks run

- `node test/goal-plugin.test.js` — 308/308 pass, including the new reproduction test (`auto-continue fires after compaction despite a pre-compaction continuation claim`), which fails on `main` (0 continuations) and passes with the fix (exactly 1).
- `npm run check` on official Node 22 — 385/385 pass.
- CHANGELOG updated.
