### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## 0.8.1 — 2026-08-07
+
 - Fix goal auto-continue stalling after session compaction: a continuation
   claim for a pre-compaction source turn could match the still-visible tail
   assistant message after compaction and suppress the post-compaction
   continuation until the user nudged the goal. The claim is now invalidated on
-  `session.compacted`, so the loop resumes on the next idle.
+  `session.compacted`, so the loop resumes on the next idle. Contributed by
+  [@harryzhou2000](https://github.com/harryzhou2000) in
+  [#58](https://github.com/willytop8/OpenCode-goal-plugin/pull/58).
+- Update the bundled `zod` dependency from 4.1.8 to 4.4.3.
 
 ## 0.8.0 — 2026-08-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
Version bump and changelog for 0.8.1.

Delivers the two merged changes that affect what npm publishes:

- **#58** — fix auto-continue stalling after session compaction. Contributed by @harryzhou2000.
- **#52** — zod 4.1.8 → 4.4.3, the package's only runtime dependency.

`#37` (GitHub Actions bumps) and `#44` (TypeScript 5.9.3 → 7.0.2) are CI and dev-only and do not reach the published package.

`npm run release:check` passes end to end:

- 385/385 tests
- type contract (NodeNext + Bundler)
- 67/67 critical mutants killed
- behavior benchmark, source and packed-artifact smokes, clean-install tool registration
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- packs as `opencode-goal-plugin-0.8.1.tgz`