### PR TITLE
fix: harden post-compaction continuation guard (supersedes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- Harden the post-compaction goal continuation guard introduced in
+  [#58](https://github.com/willytop8/OpenCode-goal-plugin/pull/58). Building on
+  the epoch-guard groundwork contributed by
+  [@harryzhou2000](https://github.com/harryzhou2000), the stalled-compaction
+  circuit breaker no longer misfires on two conditions that OpenCode produces in
+  practice:
+  - A re-delivered `session.compacted` event no longer counts as a second
+    compaction. Real OpenCode compaction events carry only a `sessionID` (no
+    identity field), so identity-based deduplication could never fire against a
+    live host; a duplicate host delivery could therefore trip the two-strike
+    breaker and abort the session. Re-deliveries are now recognized by the
+    absence of any message activity since the previous compaction.
+  - A `[goal:complete]` or `[goal:blocked]` reported on the assistant turn that
+    a compaction retains as its continuation source is now honored instead of
+    being suppressed, so a finished goal is archived rather than driven for one
+    more redundant continuation.
+- Remove a productive-turn detection branch that inspected message parts on the
+  `message.updated` event. That event never carries parts (they arrive on
+  `message.part.updated`, which the plugin does not observe), so the check was
+  inert; the stalled-compaction breaker resets on assistant output-token
+  progress, which a tool-using turn also produces.
+
 ## 0.8.1 — 2026-08-07
 
 - Fix goal auto-continue stalling after session compaction: a continuation

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -40,6 +40,7 @@ function legacyHomeStateFilePath(env = process.env) {
   return join(homeBase(env), ".opencode-goal-plugin", "state.json")
 }
 const MAX_HISTORY_ENTRIES = 20
+const MAX_STALLED_COMPACTIONS = 2
 // Marks a plugin-synthesized parent wake so the receiving pass knows it is
 // re-examining an assistant turn that has already been scored.
 const CHILD_WAKE_EVENT_FLAG = Symbol.for("opencode-goal-plugin.childWake")
@@ -1104,6 +1105,10 @@ function resetGoalBudget(goal) {
   goal.formatFailures = 0
   goal.lastAssistantMessageID = ""
   goal.continuationClaim = null
+  goal.compactionEpoch = 0
+  goal.stalledCompactions = 0
+  goal.lastCompactionEventID = ""
+  goal.compactionSourceAssistantMessageID = ""
   goal.skipNextTerminalCheck = false
   goal.history = [...(goal.history || [])].slice(-MAX_HISTORY_ENTRIES)
 }
@@ -1433,15 +1438,30 @@ function normalizePersistedGoal(rawGoal) {
     stopReason: typeof rawGoal.stopReason === "string" ? rawGoal.stopReason : "",
     promptFailures: toNonNegativeInteger(rawGoal.promptFailures),
     formatFailures: toNonNegativeInteger(rawGoal.formatFailures),
+    compactionEpoch: toNonNegativeInteger(rawGoal.compactionEpoch),
+    stalledCompactions: toNonNegativeInteger(rawGoal.stalledCompactions),
+    lastCompactionEventID:
+      typeof rawGoal.lastCompactionEventID === "string" &&
+      rawGoal.lastCompactionEventID.length <= MAX_GOAL_META_LENGTH
+        ? rawGoal.lastCompactionEventID
+        : "",
+    compactionSourceAssistantMessageID:
+      typeof rawGoal.compactionSourceAssistantMessageID === "string" &&
+      rawGoal.compactionSourceAssistantMessageID.length <= MAX_GOAL_META_LENGTH
+        ? rawGoal.compactionSourceAssistantMessageID
+        : "",
     executionContext: normalizeExecutionContext(rawGoal.executionContext),
     continuationClaim:
       isPlainObject(rawGoal.continuationClaim) &&
       typeof rawGoal.continuationClaim.runId === "string" &&
       rawGoal.continuationClaim.runId.length <= MAX_GOAL_META_LENGTH &&
+      Number.isSafeInteger(rawGoal.continuationClaim.compactionEpoch) &&
+      rawGoal.continuationClaim.compactionEpoch >= 0 &&
       typeof rawGoal.continuationClaim.sourceAssistantMessageID === "string" &&
       rawGoal.continuationClaim.sourceAssistantMessageID.length <= MAX_GOAL_META_LENGTH
         ? {
             runId: rawGoal.continuationClaim.runId,
+            compactionEpoch: rawGoal.continuationClaim.compactionEpoch,
             sourceAssistantMessageID: rawGoal.continuationClaim.sourceAssistantMessageID,
           }
         : null,
@@ -2635,7 +2655,42 @@ function systemBlockContainsGoal(block, goalId) {
 }
 
 function findLatestAssistantMessage(messages) {
-  return [...(messages || [])].reverse().find((message) => messageRole(message) === "assistant") || null
+  return [...(messages || [])]
+    .reverse()
+    .find(
+      (message) =>
+        messageRole(message) === "assistant" && !isCompactionAssistantMessage(message),
+    ) || null
+}
+
+function isCompactionAssistantMessage(message) {
+  if (messageRole(message) !== "assistant") return false
+  const info = isPlainObject(message?.info) ? message.info : message
+  return (
+    info?.summary === true ||
+    info?.agent === "compaction" ||
+    info?.mode === "compaction" ||
+    message?.agent === "compaction" ||
+    message?.mode === "compaction"
+  )
+}
+
+function compactionEventIdentity(event) {
+  const candidates = [
+    event?.id,
+    event?.properties?.compactionID,
+    event?.properties?.summaryID,
+    event?.properties?.messageID,
+    event?.properties?.id,
+    event?.data?.compactionID,
+    event?.data?.summaryID,
+    event?.data?.messageID,
+    event?.data?.id,
+  ]
+  const identity = candidates.find(
+    (candidate) => typeof candidate === "string" && candidate.length > 0,
+  )
+  return identity && identity.length <= MAX_GOAL_META_LENGTH ? identity : ""
 }
 
 function messageParentID(message) {
@@ -2771,6 +2826,7 @@ function continuationSnapshot(messages, ownedMessages = currentRuntime().ownedPl
     .reverse()
     .find((message) =>
       (messageRole(message) === "assistant" || messageRole(message) === "user") &&
+      !isCompactionAssistantMessage(message) &&
       !isPluginGeneratedMessage(message, ownedMessages),
     )
   return {
@@ -2939,6 +2995,10 @@ function buildGoalState(sessionID, condition, options, meta = {}, lastStatus = "
     stopReason: "",
     promptFailures: 0,
     formatFailures: 0,
+    compactionEpoch: 0,
+    stalledCompactions: 0,
+    lastCompactionEventID: "",
+    compactionSourceAssistantMessageID: "",
     executionContext: normalizeExecutionContext(
       meta.executionContext || currentRuntime().sessionExecutionContexts.get(sessionID),
     ),
@@ -4397,18 +4457,19 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
     sessionID,
     goalID,
     runID,
+    compactionEpoch,
     baselineMessages,
     { refreshMessages = false } = {},
   ) => {
     const goalBeforeRefresh = activeGoal(sessionID, goalID, runID)
-    if (!goalBeforeRefresh) return null
+    if (!goalBeforeRefresh || goalBeforeRefresh.compactionEpoch !== compactionEpoch) return null
     const hostMessages = refreshMessages
       ? await sessionApi.messages(sessionID, {
           limit: goalBeforeRefresh.options.maxRecentMessages,
         })
       : baselineMessages
     const goal = activeGoal(sessionID, goalID, runID)
-    if (!goal) return null
+    if (!goal || goal.compactionEpoch !== compactionEpoch) return null
     const messages = Array.isArray(hostMessages)
       ? hostMessages.slice(-goal.options.maxRecentMessages)
       : []
@@ -4523,12 +4584,13 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
     const sourceAssistantMessageID = refreshed.latestAssistantID || "<no-assistant>"
     if (
       goal.continuationClaim?.runId === runID &&
+      goal.continuationClaim?.compactionEpoch === compactionEpoch &&
       goal.continuationClaim?.sourceAssistantMessageID === sourceAssistantMessageID
     ) {
       return null
     }
 
-    goal.continuationClaim = { runId: runID, sourceAssistantMessageID }
+    goal.continuationClaim = { runId: runID, compactionEpoch, sourceAssistantMessageID }
     const claimPersisted = await persist(sessionID)
     if (!claimPersisted && persistenceOptions.persistState) {
       goal.continuationClaim = null
@@ -4545,7 +4607,13 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
       })
       return null
     }
-    return goal
+    // Let an already-published compaction event invalidate this claim before
+    // the caller enters promptAsync. The final epoch check is the atomic edge:
+    // a claim is valid only while its context epoch is still current.
+    await Promise.resolve()
+    return activeGoal(sessionID, goalID, runID)?.compactionEpoch === compactionEpoch
+      ? goal
+      : null
   }
 
   const retireCompletedCommandTurnOnIdle = async (sessionID, messageLimit) => {
@@ -5328,15 +5396,47 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
       if (event?.type === "session.compacted") {
         const sessionID = getSessionID(event)
         const goal = goalStates.get(sessionID)
-        if (!goal) return
+        if (!goal || goal.stopped) return
+        const identity = compactionEventIdentity(event)
+        if (identity && identity === goal.lastCompactionEventID) return
+        if (identity) goal.lastCompactionEventID = identity
+
+        goal.compactionEpoch += 1
+        goal.stalledCompactions += 1
+        goal.compactionSourceAssistantMessageID =
+          goal.continuationClaim?.runId === goal.runId
+            ? goal.continuationClaim.sourceAssistantMessageID
+            : ""
         goal.messageIDs = new Set()
         goal.totalTokens = 0
-        // Compaction rewrites the context: a continuation claim for a
-        // pre-compaction source turn must not suppress the post-compaction
-        // continuation (the recent tail can still end on the same assistant
-        // message, which would otherwise stall the goal loop until the user
-        // nudges it).
+        // Compaction rewrites the context. The epoch-scoped claim lets the same
+        // retained assistant source continue once in the new epoch without
+        // allowing duplicate idle delivery to continue it twice.
         goal.continuationClaim = null
+
+        // An idle handler can already have persisted its source claim when the
+        // compaction lands. Abort its cooldown and release the per-session guard;
+        // the epoch checks around promptAsync prevent that stale handler from
+        // sending while allowing the post-compaction idle to start immediately.
+        currentRuntime().continuationControllers.get(sessionID)?.abort()
+        currentRuntime().continuationControllers.delete(sessionID)
+        activeContinues.delete(sessionID)
+
+        if (goal.stalledCompactions >= MAX_STALLED_COMPACTIONS) {
+          await pauseActiveGoal(sessionID, {
+            stopReason: "stalled compaction",
+            status: `Goal paused after ${goal.stalledCompactions} compactions without a productive assistant or tool turn.`,
+            history: `Paused after ${goal.stalledCompactions} compactions without productive non-compaction work.`,
+          })
+          if (typeof client?.session?.abort === "function") {
+            try {
+              await sessionApi.abort(sessionID)
+            } catch (error) {
+              await logPluginError(client, "Failed to abort a stalled compaction loop", error)
+            }
+          }
+          return
+        }
         await persist(sessionID)
         return
       }
@@ -5344,6 +5444,8 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
       if (event?.type === "message.updated") {
         const message = messageInfoFromEvent(event)
         if (!message) return
+        const messageEnvelope =
+          event?.properties?.message || event?.data?.message || message
 
         const currentMessageID = messageID(message)
         if (!currentMessageID) return
@@ -5395,10 +5497,24 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
 
         if (
           messageRole(message) === "assistant" &&
+          !isCompactionAssistantMessage(messageEnvelope) &&
+          currentMessageID !== goal.compactionSourceAssistantMessageID &&
           currentOutputTokens > previousOutputTokens &&
           runtime.suppressedCommandAssistants.get(currentMessageID) !== currentSessionID
         ) {
           goal.lastProgressAt = Date.now()
+          changed = true
+        }
+
+        if (
+          messageRole(message) === "assistant" &&
+          !isCompactionAssistantMessage(messageEnvelope) &&
+          currentMessageID !== goal.compactionSourceAssistantMessageID &&
+          (currentOutputTokens > previousOutputTokens || messageHasToolCall(messageEnvelope)) &&
+          goal.stalledCompactions > 0
+        ) {
+          goal.stalledCompactions = 0
+          goal.compactionSourceAssistantMessageID = ""
           changed = true
         }
 
@@ -5497,10 +5613,12 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
       if (!goal || goal.stopped || activeContinues.has(sessionID)) return
       const goalID = goal.goalId
       const runID = goal.runId
+      const compactionEpoch = goal.compactionEpoch
 
       const continueToken = randomUUID()
       const continueController = new AbortController()
       let claimedSourceAssistantMessageID = ""
+      let claimedCompactionEpoch = -1
       activeContinues.set(sessionID, continueToken)
       currentRuntime().continuationControllers.set(sessionID, continueController)
       try {
@@ -5513,7 +5631,10 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
           ? hostMessages.slice(-goal.options.maxRecentMessages)
           : []
         const activeGoalAfterMessages = activeGoal(sessionID, goalID, runID)
-        if (!activeGoalAfterMessages) return
+        if (
+          !activeGoalAfterMessages ||
+          activeGoalAfterMessages.compactionEpoch !== compactionEpoch
+        ) return
         if (!activeGoalAfterMessages.executionContext) {
           activeGoalAfterMessages.executionContext = findLatestExecutionContext(messages)
         }
@@ -5528,7 +5649,11 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
           latestAssistantID && latestAssistantID === activeGoalAfterMessages.lastAssistantMessageID
         const activationBoundary =
           currentRuntime().suppressedCommandAssistants.get(latestAssistantID) === sessionID ||
-          activeGoalAfterMessages.skipNextTerminalCheck === true
+          activeGoalAfterMessages.skipNextTerminalCheck === true ||
+          (
+            activeGoalAfterMessages.compactionSourceAssistantMessageID &&
+            activeGoalAfterMessages.compactionSourceAssistantMessageID === latestAssistantID
+          )
         activeGoalAfterMessages.skipNextTerminalCheck = false
 
         if (!activationBoundary && latestText && (!assistantRepeated || assistantChanged)) {
@@ -5555,6 +5680,7 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         const sourceAssistantMessageID = latestAssistantID || "<no-assistant>"
         if (
           activeGoalAfterMessages.continuationClaim?.runId === runID &&
+          activeGoalAfterMessages.continuationClaim?.compactionEpoch === compactionEpoch &&
           activeGoalAfterMessages.continuationClaim?.sourceAssistantMessageID ===
             sourceAssistantMessageID
         ) {
@@ -5801,6 +5927,7 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
               sessionID,
               goalID,
               runID,
+              compactionEpoch,
               messages,
             )
             if (!claimedGoal) return
@@ -6014,12 +6141,16 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
           sessionID,
           goalID,
           runID,
+          compactionEpoch,
           messages,
           { refreshMessages: cooldownWaited },
         )
         if (!activeGoalBeforePrompt) return
         claimedSourceAssistantMessageID =
           activeGoalBeforePrompt.continuationClaim?.sourceAssistantMessageID || ""
+        claimedCompactionEpoch =
+          activeGoalBeforePrompt.continuationClaim?.compactionEpoch ?? -1
+        if (claimedCompactionEpoch !== activeGoalBeforePrompt.compactionEpoch) return
 
         const budgetWrapup = budgetWrapupNeeded(activeGoalBeforePrompt)
         if (budgetWrapup) {
@@ -6115,6 +6246,8 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
           const activeGoalAfterPrompt = currentGoal(sessionID, goalID, runID)
           const message = `Auto-continue failed: ${response.error.name || "unknown error"}`
           if (
+            activeGoalAfterPrompt?.continuationClaim?.compactionEpoch ===
+              claimedCompactionEpoch &&
             activeGoalAfterPrompt?.continuationClaim?.sourceAssistantMessageID ===
             claimedSourceAssistantMessageID
           ) {
@@ -6133,6 +6266,8 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         } else {
           const activeGoalAfterPrompt = currentGoal(sessionID, goalID, runID)
           if (
+            activeGoalAfterPrompt?.continuationClaim?.compactionEpoch ===
+              claimedCompactionEpoch &&
             activeGoalAfterPrompt?.continuationClaim?.sourceAssistantMessageID ===
             claimedSourceAssistantMessageID
           ) {
@@ -6164,6 +6299,8 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         if (activeGoalAfterError) {
           if (
             claimedSourceAssistantMessageID &&
+            activeGoalAfterError.continuationClaim?.compactionEpoch ===
+              claimedCompactionEpoch &&
             activeGoalAfterError.continuationClaim?.sourceAssistantMessageID ===
               claimedSourceAssistantMessageID
           ) {

--- a/src/goal-plugin.js
+++ b/src/goal-plugin.js
@@ -1108,6 +1108,7 @@ function resetGoalBudget(goal) {
   goal.compactionEpoch = 0
   goal.stalledCompactions = 0
   goal.lastCompactionEventID = ""
+  goal.messageSeenSinceCompaction = true
   goal.compactionSourceAssistantMessageID = ""
   goal.skipNextTerminalCheck = false
   goal.history = [...(goal.history || [])].slice(-MAX_HISTORY_ENTRIES)
@@ -1445,6 +1446,7 @@ function normalizePersistedGoal(rawGoal) {
       rawGoal.lastCompactionEventID.length <= MAX_GOAL_META_LENGTH
         ? rawGoal.lastCompactionEventID
         : "",
+    messageSeenSinceCompaction: rawGoal.messageSeenSinceCompaction !== false,
     compactionSourceAssistantMessageID:
       typeof rawGoal.compactionSourceAssistantMessageID === "string" &&
       rawGoal.compactionSourceAssistantMessageID.length <= MAX_GOAL_META_LENGTH
@@ -2998,6 +3000,7 @@ function buildGoalState(sessionID, condition, options, meta = {}, lastStatus = "
     compactionEpoch: 0,
     stalledCompactions: 0,
     lastCompactionEventID: "",
+    messageSeenSinceCompaction: true,
     compactionSourceAssistantMessageID: "",
     executionContext: normalizeExecutionContext(
       meta.executionContext || currentRuntime().sessionExecutionContexts.get(sessionID),
@@ -5398,8 +5401,20 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         const goal = goalStates.get(sessionID)
         if (!goal || goal.stopped) return
         const identity = compactionEventIdentity(event)
-        if (identity && identity === goal.lastCompactionEventID) return
-        if (identity) goal.lastCompactionEventID = identity
+        if (identity) {
+          if (identity === goal.lastCompactionEventID) return
+          goal.lastCompactionEventID = identity
+        } else if (goal.compactionEpoch > 0 && !goal.messageSeenSinceCompaction) {
+          // A real OpenCode `session.compacted` carries only `sessionID` (SDK:
+          // EventSessionCompacted has no id/compactionID/summaryID/messageID and
+          // no sync variant), so compactionEventIdentity() returns "" for every
+          // host-delivered compaction and the identity dedup above never fires
+          // in production. Recognize a re-delivery by the absence of message
+          // activity instead: a genuine new compaction is always preceded by
+          // messages, because the context has to grow again to trigger one.
+          return
+        }
+        goal.messageSeenSinceCompaction = false
 
         goal.compactionEpoch += 1
         goal.stalledCompactions += 1
@@ -5455,6 +5470,13 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         const goal = goalStates.get(currentSessionID)
         if (!goal) return
 
+        // Any message traffic for this goal marks the current compaction epoch
+        // as having seen activity, which is what lets an identity-less
+        // `session.compacted` re-delivery be told apart from a real one. Recorded
+        // before the stale-redelivery guard below: a message that is stale for
+        // token accounting still proves the host is delivering message events.
+        goal.messageSeenSinceCompaction = true
+
         // Skip stale re-deliveries from a prior budget window or a replaced goal.
         // resetGoalBudget and cleanupGoal both leave seenTokens entries in place
         // so this guard can fire: if an ID is already recorded in seenTokens but
@@ -5506,11 +5528,18 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
           changed = true
         }
 
+        // Productive-turn reset. `message.updated` carries only
+        // `properties.info` (SDK: EventMessageUpdated) and never any parts —
+        // tool parts arrive on the separate `message.part.updated` event, which
+        // this plugin does not observe. A messageHasToolCall() check against the
+        // event envelope is therefore always false and cannot serve as the reset
+        // signal. Growing output tokens is the signal that does work: an
+        // assistant turn that calls a tool still emits output tokens for it.
         if (
           messageRole(message) === "assistant" &&
           !isCompactionAssistantMessage(messageEnvelope) &&
           currentMessageID !== goal.compactionSourceAssistantMessageID &&
-          (currentOutputTokens > previousOutputTokens || messageHasToolCall(messageEnvelope)) &&
+          currentOutputTokens > previousOutputTokens &&
           goal.stalledCompactions > 0
         ) {
           goal.stalledCompactions = 0
@@ -5647,12 +5676,20 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         const assistantChanged = summarizeText(latestText) !== summarizeText(previousAssistantText)
         const assistantRepeated =
           latestAssistantID && latestAssistantID === activeGoalAfterMessages.lastAssistantMessageID
-        const activationBoundary =
+        // A retained pre-compaction assistant must not be scored as fresh
+        // progress, so the compaction source gates checkpointing and the stall
+        // heuristics. It must NOT gate the terminal checks: a [goal:complete] or
+        // [goal:blocked] on that retained turn has not been acted on yet — it
+        // survived the compaction unprocessed — and swallowing it discards a
+        // real result and spends another continuation to re-derive it.
+        const terminalBoundary =
           currentRuntime().suppressedCommandAssistants.get(latestAssistantID) === sessionID ||
-          activeGoalAfterMessages.skipNextTerminalCheck === true ||
-          (
+          activeGoalAfterMessages.skipNextTerminalCheck === true
+        const activationBoundary =
+          terminalBoundary ||
+          Boolean(
             activeGoalAfterMessages.compactionSourceAssistantMessageID &&
-            activeGoalAfterMessages.compactionSourceAssistantMessageID === latestAssistantID
+            activeGoalAfterMessages.compactionSourceAssistantMessageID === latestAssistantID,
           )
         activeGoalAfterMessages.skipNextTerminalCheck = false
 
@@ -5695,7 +5732,7 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
         let completionUnverified = false
         let blockerUnstated = false
 
-        if (!activationBoundary && goalIsComplete(latestText)) {
+        if (!terminalBoundary && goalIsComplete(latestText)) {
           const evidence = extractCompletionEvidence(latestText)
           if (evidence) {
             await announceAudit(
@@ -5857,7 +5894,7 @@ async function createGoalPlugin({ client, directory } = {}, pluginOptions = {}) 
             "completion-unverified",
             "Assistant output [goal:complete] without a [goal:evidence] line; completion rejected, continuing.",
           )
-        } else if (!activationBoundary && goalIsBlocked(latestText)) {
+        } else if (!terminalBoundary && goalIsBlocked(latestText)) {
           const reason = extractBlockedReason(latestText)
           if (reason) {
             await announceAudit(

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -4369,7 +4369,10 @@ test("auto-continue fires after compaction despite a pre-compaction continuation
     app: { log: async () => {} },
     session: {
       messages: async () => ({
-        data: [pluginContinuationMessage(), message("did a step")],
+        data: [
+          pluginContinuationMessage(),
+          message("did a step", { input: 1, output: 1, reasoning: 0 }),
+        ],
       }),
       promptAsync: async (input) => {
         calls.push(input)
@@ -4379,7 +4382,7 @@ test("auto-continue fires after compaction despite a pre-compaction continuation
   }
   const hooks = await GoalPlugin(
     { client },
-    { persistState: false, minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+    { persistState: false, minDelayMs: 1, noToolCallTurnsBeforePause: 1 },
   )
   await hooks["command.execute.before"](
     { command: "goal", sessionID: "session-1", arguments: "ship it" },
@@ -4392,11 +4395,28 @@ test("auto-continue fires after compaction despite a pre-compaction continuation
   // compaction interrupted it; after compaction the recent tail still ends on
   // that same assistant message, so the stale claim must not suppress the
   // post-compaction continuation.
-  goal.continuationClaim = { runId: goal.runId, sourceAssistantMessageID: "msg-assistant" }
+  goal.continuationClaim = {
+    runId: goal.runId,
+    compactionEpoch: goal.compactionEpoch,
+    sourceAssistantMessageID: "msg-assistant",
+  }
 
   await hooks.event({
     event: { type: "session.compacted", properties: { sessionID: "session-1" } },
   })
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        message: message(
+          "did a step",
+          { input: 1, output: 1, reasoning: 0 },
+          "msg-assistant",
+        ),
+      },
+    },
+  })
+  assert.equal(goal.stalledCompactions, 1, "retained source is not new work progress")
 
   await hooks.event({
     event: { type: "session.status", properties: { sessionID: "session-1", status: { type: "idle" } } },
@@ -4404,6 +4424,200 @@ test("auto-continue fires after compaction despite a pre-compaction continuation
 
   assert.equal(calls.length, 1)
   assert.equal(currentGoal("session-1").stopped, false)
+  assert.equal(currentGoal("session-1").compactionEpoch, 1)
+  assert.deepEqual(currentGoal("session-1").continuationClaim, {
+    runId: goal.runId,
+    compactionEpoch: 1,
+    sourceAssistantMessageID: "msg-assistant",
+  })
+
+  await hooks.event({
+    event: { id: "idle-after-compact-duplicate", type: "session.status", properties: { sessionID: "session-1", status: { type: "idle" } } },
+  })
+  assert.equal(calls.length, 1, "one compaction epoch must send only one continuation")
+})
+
+test("duplicate session.compacted delivery does not open another continuation epoch", async () => {
+  const { calls, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID: "session-compact-duplicate", arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const compacted = {
+    id: "compact-event-1",
+    type: "session.compacted",
+    properties: { sessionID: "session-compact-duplicate" },
+  }
+  await hooks.event({ event: compacted })
+  await hooks.event({
+    event: { id: "idle-compact-1", type: "session.status", properties: { sessionID: "session-compact-duplicate", status: { type: "idle" } } },
+  })
+  await hooks.event({ event: structuredClone(compacted) })
+  await hooks.event({
+    event: { id: "idle-compact-2", type: "session.status", properties: { sessionID: "session-compact-duplicate", status: { type: "idle" } } },
+  })
+
+  const goal = currentGoal("session-compact-duplicate")
+  assert.equal(calls.length, 1)
+  assert.equal(goal.compactionEpoch, 1)
+  assert.equal(goal.stalledCompactions, 1)
+  assert.equal(goal.stopped, false)
+})
+
+test("repeated compactions without work progress pause and abort the active goal", async () => {
+  const { aborts, calls, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-stalled"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  await hooks.event({
+    event: { id: "compact-stalled-1", type: "session.compacted", properties: { sessionID } },
+  })
+  await hooks.event({
+    event: { id: "idle-stalled-1", type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+  })
+  await hooks.event({
+    event: { id: "compact-stalled-2", type: "session.compacted", properties: { sessionID } },
+  })
+
+  const goal = currentGoal(sessionID)
+  assert.equal(calls.length, 1)
+  assert.equal(aborts.length, 1)
+  assert.equal(aborts[0].path.id, sessionID)
+  assert.equal(goal.compactionEpoch, 2)
+  assert.equal(goal.stalledCompactions, 2)
+  assert.equal(goal.stopped, true)
+  assert.equal(goal.stopReason, "stalled compaction")
+})
+
+test("a productive tool turn resets the stalled-compaction circuit breaker", async () => {
+  const { aborts, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-progress"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  await hooks.event({
+    event: { id: "compact-progress-1", type: "session.compacted", properties: { sessionID } },
+  })
+  const toolTurn = {
+    info: {
+      id: "msg-tool-progress",
+      role: "assistant",
+      sessionID,
+      tokens: { input: 1, output: 0, reasoning: 0 },
+    },
+    parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
+  }
+  await hooks.event({
+    event: { type: "message.updated", properties: { message: toolTurn } },
+  })
+  assert.equal(currentGoal(sessionID).stalledCompactions, 0)
+
+  await hooks.event({
+    event: { id: "compact-progress-2", type: "session.compacted", properties: { sessionID } },
+  })
+  const goal = currentGoal(sessionID)
+  assert.equal(aborts.length, 0)
+  assert.equal(goal.stalledCompactions, 1)
+  assert.equal(goal.stopped, false)
+})
+
+test("compaction-summary assistants are neither progress nor continuation sources", async () => {
+  const workAssistant = message(
+    "implemented the next step",
+    undefined,
+    "msg-real-work",
+    "session-compact-summary",
+  )
+  const compactSummary = {
+    info: {
+      id: "msg-compact-summary",
+      role: "assistant",
+      sessionID: "session-compact-summary",
+      summary: true,
+      mode: "compaction",
+      tokens: { input: 100, output: 100, reasoning: 0 },
+    },
+    parts: [textPart("What did we do so far?")],
+  }
+  const { aborts, calls, hooks } = await createHooks({
+    messages: async () => ({ data: [workAssistant, compactSummary] }),
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-summary"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  await hooks.event({
+    event: { id: "compact-summary-1", type: "session.compacted", properties: { sessionID } },
+  })
+  await hooks.event({
+    event: { type: "message.updated", properties: { message: compactSummary } },
+  })
+  assert.equal(currentGoal(sessionID).stalledCompactions, 1)
+
+  await hooks.event({
+    event: { id: "idle-compact-summary", type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+  })
+  assert.equal(calls.length, 1)
+  assert.equal(currentGoal(sessionID).continuationClaim.sourceAssistantMessageID, "msg-real-work")
+
+  await hooks.event({
+    event: { id: "compact-summary-2", type: "session.compacted", properties: { sessionID } },
+  })
+  assert.equal(aborts.length, 1)
+  assert.equal(currentGoal(sessionID).stopReason, "stalled compaction")
+})
+
+test("compaction after claim persistence invalidates the stale idle handler", async () => {
+  const { calls, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-claim-race"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  const goal = currentGoal(sessionID)
+  let claim = null
+  let compactionPromise = null
+  Object.defineProperty(goal, "continuationClaim", {
+    configurable: true,
+    get: () => claim,
+    set: (value) => {
+      claim = value
+      if (value && !compactionPromise) {
+        queueMicrotask(() => {
+          compactionPromise = hooks.event({
+            event: { id: "compact-claim-race", type: "session.compacted", properties: { sessionID } },
+          })
+        })
+      }
+    },
+  })
+
+  await hooks.event({
+    event: { id: "idle-claim-race", type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+  })
+  await compactionPromise
+
+  assert.equal(calls.length, 0)
+  assert.equal(goal.compactionEpoch, 1)
+  assert.equal(goal.continuationClaim, null)
 })
 
 test("parses --max-duration-ms flag directly", () => {
@@ -4776,6 +4990,7 @@ test("continuation source claims and initiating execution context persist before
     })
     assert.deepEqual(goal.continuationClaim, {
       runId: goal.runId,
+      compactionEpoch: 0,
       sourceAssistantMessageID: "assistant-durable-source",
     })
 

--- a/test/goal-plugin.test.js
+++ b/test/goal-plugin.test.js
@@ -4507,30 +4507,171 @@ test("a productive tool turn resets the stalled-compaction circuit breaker", asy
     { parts: [] },
   )
 
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
+  // Canonical host shape: EventMessageUpdated is { type, properties: { info } }.
+  // Parts never ride on this event, so a tool-calling turn is recognized by the
+  // output tokens it emitted, not by inspecting parts on the envelope.
   await hooks.event({
-    event: { id: "compact-progress-1", type: "session.compacted", properties: { sessionID } },
-  })
-  const toolTurn = {
-    info: {
-      id: "msg-tool-progress",
-      role: "assistant",
-      sessionID,
-      tokens: { input: 1, output: 0, reasoning: 0 },
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-tool-progress",
+          role: "assistant",
+          sessionID,
+          tokens: { input: 1, output: 64, reasoning: 0 },
+        },
+      },
     },
-    parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
-  }
-  await hooks.event({
-    event: { type: "message.updated", properties: { message: toolTurn } },
   })
   assert.equal(currentGoal(sessionID).stalledCompactions, 0)
 
-  await hooks.event({
-    event: { id: "compact-progress-2", type: "session.compacted", properties: { sessionID } },
-  })
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
   const goal = currentGoal(sessionID)
   assert.equal(aborts.length, 0)
   assert.equal(goal.stalledCompactions, 1)
   assert.equal(goal.stopped, false)
+})
+
+test("a re-delivered identity-less compaction does not trip the circuit breaker", async () => {
+  const { aborts, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-redelivery"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  // A real EventSessionCompacted carries only sessionID, so a host re-delivery
+  // is indistinguishable by identity. Delivering the same event twice must not
+  // count as two compactions and must not pause or abort the session.
+  const compacted = { type: "session.compacted", properties: { sessionID } }
+  await hooks.event({ event: compacted })
+  assert.equal(currentGoal(sessionID).stalledCompactions, 1)
+
+  await hooks.event({ event: compacted })
+  const goal = currentGoal(sessionID)
+  assert.equal(goal.stalledCompactions, 1)
+  assert.equal(goal.compactionEpoch, 1)
+  assert.equal(goal.stopped, false)
+  assert.equal(aborts.length, 0)
+})
+
+test("identity-less compactions separated by message activity still trip the breaker", async () => {
+  const { aborts, hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-genuine"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
+  // Message traffic between the two compactions proves the second is genuine
+  // rather than a re-delivery. A compaction summary is activity but not
+  // productive work, so the breaker must still close.
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-compaction-summary",
+          role: "assistant",
+          sessionID,
+          summary: true,
+          mode: "compaction",
+          tokens: { input: 100, output: 100, reasoning: 0 },
+        },
+      },
+    },
+  })
+  assert.equal(currentGoal(sessionID).stalledCompactions, 1)
+
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
+  const goal = currentGoal(sessionID)
+  assert.equal(goal.stalledCompactions, 2)
+  assert.equal(goal.stopped, true)
+  assert.equal(goal.stopReason, "stalled compaction")
+  assert.equal(aborts.length, 1)
+})
+
+test("tool parts decorating a message.updated event are not a productive-turn signal", async () => {
+  const { hooks } = await createHooks({
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  const sessionID = "session-compact-parts"
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
+  // The host never puts parts on message.updated; they arrive on
+  // message.part.updated, which this plugin does not observe. Nothing may come
+  // to depend on parts here, because in production they are always absent.
+  await hooks.event({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg-no-output",
+          role: "assistant",
+          sessionID,
+          tokens: { input: 1, output: 0, reasoning: 0 },
+        },
+        parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
+      },
+    },
+  })
+  assert.equal(currentGoal(sessionID).stalledCompactions, 1)
+})
+
+test("a completion claim on the retained compaction source is honored", async () => {
+  const sessionID = "session-compact-complete"
+  let sessionMessages = []
+  const { calls, hooks } = await createHooks({
+    messages: async () => ({ data: sessionMessages }),
+    options: { minDelayMs: 1, noToolCallTurnsBeforePause: 0 },
+  })
+  await hooks["command.execute.before"](
+    { command: "goal", sessionID, arguments: "ship it" },
+    { parts: [] },
+  )
+
+  // An idle establishes a continuation claim sourced from msg-retained.
+  sessionMessages = [message("still working", undefined, "msg-retained", sessionID)]
+  await hooks.event({
+    event: { type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+  })
+  assert.equal(
+    currentGoal(sessionID).continuationClaim.sourceAssistantMessageID,
+    "msg-retained",
+  )
+
+  // Compaction retains that same assistant as the epoch's source turn.
+  await hooks.event({ event: { type: "session.compacted", properties: { sessionID } } })
+  assert.equal(currentGoal(sessionID).compactionSourceAssistantMessageID, "msg-retained")
+
+  // That retained turn is the one carrying the completion claim, and it survived
+  // the compaction unprocessed. Suppressing it would discard a real result and
+  // spend another continuation re-deriving it.
+  sessionMessages = [
+    message(
+      "All done.\n[goal:evidence] ran npm test, 313 pass\n[goal:complete]",
+      undefined,
+      "msg-retained",
+      sessionID,
+    ),
+  ]
+  const callsBefore = calls.length
+  await hooks.event({
+    event: { type: "session.status", properties: { sessionID, status: { type: "idle" } } },
+  })
+
+  assert.equal(currentGoal(sessionID), null)
+  assert.equal(calls.length, callsBefore)
 })
 
 test("compaction-summary assistants are neither progress nor continuation sources", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #61 (and #58 before it) hardening the post-compaction goal
continuation guard. This branch keeps @harryzhou2000's epoch-guard work from #61
as its base — his commit is preserved — and corrects three issues that only
surface against the event shapes OpenCode actually emits.

The event shapes were confirmed against the vendored `@opencode-ai/sdk`
type definitions rather than inferred from test fixtures:

- `EventMessageUpdated` is `{ type, properties: { sessionID, info } }` — it never
  carries `parts`. Parts arrive on `message.part.updated`, which this plugin does
  not observe.
- `EventSessionCompacted` is `{ type, properties: { sessionID } }` — no `id`, no
  `compactionID`/`summaryID`/`messageID`, and no sync variant in the plugin-facing
  `Event` union.

## What changes

1. **Identity-less compaction re-delivery no longer trips the breaker.** Because a
   real `session.compacted` has no identity field, the identity-based dedup from
   #61 can never fire against a live host, so a single duplicate delivery would
   reach `MAX_STALLED_COMPACTIONS` and abort the session. Re-deliveries are now
   recognized by the absence of any message activity since the previous
   compaction (a genuine new compaction is always preceded by messages, since the
   context has to grow again to trigger one). New `messageSeenSinceCompaction`
   flag, persisted and restored fail-open.

2. **A completion/blocked claim on the retained compaction source is honored.**
   The terminal checks (`[goal:complete]` / `[goal:blocked]`) are split off from
   the progress/checkpoint boundary. The compaction source still gates
   checkpointing and stall heuristics, but no longer suppresses a terminal claim
   on the retained turn — which had survived the compaction unprocessed, so
   swallowing it discarded a real result and spent another continuation.

3. **Remove the inert tool-part detection branch.** `messageHasToolCall` against
   the `message.updated` envelope is always false (no parts on that event), so it
   was dead. The breaker resets on assistant output-token progress, which a
   tool-using turn also produces. `messageHasToolCall` is unchanged and still
   correct at its other call site, which reads API-fetched messages that do carry
   parts.

## Tests

- Rewrote the productive-turn test onto the canonical `properties.info` shape with
  realistic output tokens (the original used an envelope OpenCode does not emit and
  `output: 0`, which rested the assertion entirely on the now-removed branch).
- Added: identity-less re-delivery does not trip the breaker; a completion claim
  on the retained compaction source is honored; identity-less compactions
  separated by message activity still trip the breaker; tool parts on a
  `message.updated` event are not a productive-turn signal. The first two fail
  against this branch's base with the source fix reverted.

## Verification

`npm test` (394/394), `npm run type:check`, `npm run test:mutation` (67/67),
`npm run smoke`, all green; also green on Node 18.

## Not included (deliberately)

- Whether to raise `MAX_STALLED_COMPACTIONS` or drop the `session.abort` on trip
  is left as a separate discussion; the false-positive paths that made the abort
  dangerous are closed here.
- The idle-event dedup reads `event?.id`, but `EventSessionStatus` /
  `EventSessionIdle` carry no `id` either, so `seenIdleEventIDs` never dedups in
  production. Same class of issue as (1), predates #61 — worth its own issue.

Closes #61.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
