### PR TITLE
chore(release): 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.8.2 — 2026-08-21
+
 - Harden the post-compaction goal continuation guard introduced in
   [#58](https://github.com/willytop8/OpenCode-goal-plugin/pull/58). Building on
   the epoch-guard groundwork contributed by

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-goal-plugin",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-goal-plugin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Durable, guarded goal workflows for OpenCode.",
   "type": "module",
   "main": "./src/goal-plugin.js",


### PR DESCRIPTION
Release 0.8.2 — post-compaction guard hardening. Bundles #62 (fix) with the version bump and dated changelog. All release:check gates green locally.